### PR TITLE
Add support for BorrowMut

### DIFF
--- a/crates/borrowme-macros/src/ctxt.rs
+++ b/crates/borrowme-macros/src/ctxt.rs
@@ -6,8 +6,10 @@ use proc_macro2::{Span, TokenStream};
 pub(crate) struct Ctxt {
     errors: RefCell<Vec<syn::Error>>,
     pub(crate) borrowme_borrow_t_borrow: syn::Path,
+    pub(crate) borrowme_borrow_mut_t_borrow_mut: syn::Path,
     pub(crate) clone_t_clone: syn::Path,
     pub(crate) borrowme_borrow_t: syn::Path,
+    pub(crate) borrowme_borrow_mut_t: syn::Path,
     pub(crate) borrowme_to_owned_t: syn::Path,
     pub(crate) borrowme_to_owned_t_borrow: syn::Path,
 }
@@ -17,7 +19,9 @@ impl Ctxt {
         Self {
             errors: RefCell::new(Vec::new()),
             borrowme_borrow_t_borrow: path(span, ["borrowme", "Borrow", "borrow"]),
+            borrowme_borrow_mut_t_borrow_mut: path(span, ["borrowme", "BorrowMut", "borrow_mut"]),
             borrowme_borrow_t: path(span, ["borrowme", "Borrow"]),
+            borrowme_borrow_mut_t: path(span, ["borrowme", "BorrowMut"]),
             borrowme_to_owned_t: path(span, ["borrowme", "ToOwned"]),
             clone_t_clone: path(span, ["core", "clone", "Clone", "clone"]),
             borrowme_to_owned_t_borrow: path(span, ["borrowme", "ToOwned", "to_owned"]),

--- a/crates/borrowme/src/borrow_mut/std.rs
+++ b/crates/borrowme/src/borrow_mut/std.rs
@@ -1,0 +1,109 @@
+use std::collections::{BTreeMap, HashMap, LinkedList};
+use std::hash::Hash;
+
+use crate::{Borrow, BorrowMut};
+
+impl BorrowMut for String {
+    type TargetMut<'a> = &'a mut String;
+
+    #[inline]
+    fn borrow_mut(&mut self) -> Self::TargetMut<'_> {
+        self
+    }
+}
+
+macro_rules! seq {
+    (cap $seq:ident, $insert:ident $(, $trait:path)* $(,)?) => {
+        impl<T> BorrowMut for $seq<T>
+        where
+            T: BorrowMut,
+            $(for<'a> T::TargetMut<'a>: $trait,)*
+        {
+            type TargetMut<'a> = $seq<T::TargetMut<'a>> where T: 'a;
+
+            #[inline]
+            fn borrow_mut(&mut self) -> Self::TargetMut<'_> {
+                let mut out = <$seq<_>>::with_capacity(self.len());
+
+                for value in self {
+                    out.$insert(value.borrow_mut());
+                }
+
+                out
+            }
+        }
+    };
+
+    ($seq:ident, $insert:ident $(, $trait:path)* $(,)?) => {
+        impl<T> BorrowMut for $seq<T>
+        where
+            T: BorrowMut,
+            $(for<'a> T::TargetMut<'a>: $trait,)*
+        {
+            type TargetMut<'a> = $seq<T::TargetMut<'a>> where T: 'a;
+
+            #[inline]
+            fn borrow_mut(&mut self) -> Self::TargetMut<'_> {
+                let mut out = <$seq<_>>::new();
+
+                for value in self {
+                    out.$insert(value.borrow_mut());
+                }
+
+                out
+            }
+        }
+    };
+}
+
+macro_rules! map {
+    (cap $map:ident, $insert:ident $(, $trait:path)* $(,)?) => {
+        impl<K, V> BorrowMut for $map<K, V>
+        where
+            K: Borrow,
+            V: BorrowMut,
+            $(for<'a> K::Target<'a>: $trait,)*
+        {
+            type TargetMut<'a> = $map<K::Target<'a>, V::TargetMut<'a>> where K: 'a, V: 'a;
+
+            #[inline]
+            fn borrow_mut(&mut self) -> Self::TargetMut<'_> {
+                let mut out = <$map<_, _>>::with_capacity(self.len());
+
+                for (key, value) in self {
+                    out.$insert(key.borrow(), value.borrow_mut());
+                }
+
+                out
+            }
+        }
+    };
+
+    ($map:ident, $insert:ident $(, $trait:path)* $(,)?) => {
+        impl<K, V> BorrowMut for $map<K, V>
+        where
+            K: Borrow,
+            V: BorrowMut,
+            $(for<'a> K::Target<'a>: $trait,)*
+        {
+            type TargetMut<'a> = $map<K::Target<'a>, V::TargetMut<'a>> where K: 'a, V: 'a;
+
+            #[inline]
+            fn borrow_mut(&mut self) -> Self::TargetMut<'_> {
+                let mut out = <$map<_, _>>::new();
+
+                for (key, value) in self {
+                    out.$insert(key.borrow(), value.borrow_mut());
+                }
+
+                out
+            }
+        }
+    };
+}
+
+seq!(cap Vec, push);
+seq!(LinkedList, push_back);
+
+map!(cap HashMap, insert, Hash, Eq);
+map!(BTreeMap, insert, PartialOrd, Ord, Eq);

--- a/crates/borrowme/src/to_owned/std.rs
+++ b/crates/borrowme/src/to_owned/std.rs
@@ -15,6 +15,24 @@ impl ToOwned for str {
     }
 }
 
+impl ToOwned for String {
+    type Owned = String;
+
+    #[inline]
+    fn to_owned(&self) -> Self::Owned {
+        String::from(self.as_str())
+    }
+}
+
+impl ToOwned for &mut String {
+    type Owned = String;
+
+    #[inline]
+    fn to_owned(&self) -> Self::Owned {
+        String::from(self.as_str())
+    }
+}
+
 impl<T> ToOwned for Option<T>
 where
     T: ToOwned,

--- a/crates/borrowme/tests/borrow_mut.rs
+++ b/crates/borrowme/tests/borrow_mut.rs
@@ -1,0 +1,28 @@
+use borrowme::borrowme;
+
+#[borrowme]
+struct Inner<'a> {
+    text: &'static str,
+    lang: &'a mut String,
+}
+
+#[borrowme]
+struct BorrowMutStruct<'a> {
+    text: &'a str,
+    #[borrowme(mut)]
+    inner: Inner<'a>,
+}
+
+#[borrowme]
+enum BorrowMutEnum<'a> {
+    Variant {
+        text: &'a str,
+        #[borrowme(mut)]
+        inner: Inner<'a>,
+    },
+    Variant2 {
+        text: &'a str,
+        #[borrowme(mut)]
+        inner: Inner<'a>,
+    },
+}


### PR DESCRIPTION
This introduces and adds support for deriving `BorrowMut` if mutable access is required. Mutable access is determined if a mutable reference is observed in the field type or if `#[borrowme(mut)]` is specified.

A type can either implement `Borrow` or `BorrowMut`, borrowed fields are supported for `BorrowMut` implementations but not vice versa.

Since compositional types do not have a mutable reference, the `#[borrowme(mut)]` attribute is required to make these work.

```rust
#[borrowme]
struct Inner<'a> {
    text: &'static str,
    lang: &'a mut String,
}

#[borrowme]
struct BorrowMutStruct<'a> {
    text: &'a str,
    #[borrowme(mut)]
    inner: Inner<'a>,
}
```